### PR TITLE
feat(s3): Add min.io, update otel stack to use it for object storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This project is in its **earliest stages**. The public repo documents the ongoin
     - `Parameters:kc-password` (Keycloak password)
     - `Parameters:otel-username` (Grafana username)
     - `Parameters:otel-password` (Grafana password)
+    - `Parameters:s3-username` (MinIO username)
+    - `Parameters:s3-password` (MinIO password)
 
     If you want to verify your entries, use the `dotnet user-secrets list` command.
 

--- a/observability/loki/config/loki.yaml
+++ b/observability/loki/config/loki.yaml
@@ -11,9 +11,14 @@ server:
 common:
   path_prefix: /loki
   storage:
-    filesystem:
-      chunks_directory: /loki/chunks
-      rules_directory: /loki/rules
+    # S3-compatible MinIO storage
+    s3:
+      endpoint: d2-minio:9000
+      bucketnames: loki-logs
+      access_key_id: ${MINIO_ROOT_USER}
+      secret_access_key: ${MINIO_ROOT_PASSWORD}
+      insecure: true
+      s3forcepathstyle: true
   replication_factor: 1
   ring:
     instance_addr: 127.0.0.1
@@ -24,7 +29,7 @@ schema_config:
   configs:
     - from: 2025-01-01
       store: tsdb
-      object_store: filesystem
+      object_store: s3
       schema: v13
       index:
         prefix: index_
@@ -36,11 +41,11 @@ compactor:
   delete_request_store: filesystem
 
 limits_config:
-  retention_period: 672h
+  retention_period: 8640h  # 360 days
 
 table_manager:
   retention_deletes_enabled: true
-  retention_period: 672h
+  retention_period: 8640h  # 360 days
 
 frontend:
   log_queries_longer_than: 5s

--- a/observability/mimir/config/mimir.yaml
+++ b/observability/mimir/config/mimir.yaml
@@ -11,14 +11,26 @@ server:
 
 common:
   storage:
-    backend: filesystem
-    filesystem:
-      dir: /var/mimir/data
+    backend: s3
+    s3:
+      endpoint: d2-minio:9000
+      bucket_name: mimir-blocks
+      access_key_id: ${MINIO_ROOT_USER}
+      secret_access_key: ${MINIO_ROOT_PASSWORD}
+      insecure: true
+      http:
+        insecure_skip_verify: true
+      signature_version: v4
+      storage_class: STANDARD
 
 blocks_storage:
-  backend: filesystem
-  filesystem:
-    dir: /var/mimir/blocks
+  backend: s3
+  s3:
+    endpoint: d2-minio:9000
+    bucket_name: mimir-blocks
+    access_key_id: ${MINIO_ROOT_USER}
+    secret_access_key: ${MINIO_ROOT_PASSWORD}
+    insecure: true
   tsdb:
     dir: /var/mimir/tsdb
   bucket_store:
@@ -51,12 +63,16 @@ store_gateway:
       store: inmemory
 
 ruler_storage:
-  backend: filesystem
-  filesystem:
-    dir: /var/mimir/rules
+  backend: s3
+  s3:
+    endpoint: d2-minio:9000
+    bucket_name: mimir-ruler
+    access_key_id: ${MINIO_ROOT_USER}
+    secret_access_key: ${MINIO_ROOT_PASSWORD}
+    insecure: true
 
 limits:
-  compactor_blocks_retention_period: 672h
+  compactor_blocks_retention_period: 2160h  # 90 days
 
 activity_tracker:
   filepath: /var/mimir/activity.log

--- a/observability/tempo/config/tempo.yaml
+++ b/observability/tempo/config/tempo.yaml
@@ -23,8 +23,18 @@ metrics_generator:
 
 storage:
   trace:
-    backend: local
-    local:
-      path: /var/tempo/traces
+    backend: s3
+    s3:
+      bucket: tempo-traces
+      endpoint: d2-minio:9000
+      access_key: ${MINIO_ROOT_USER}
+      secret_key: ${MINIO_ROOT_PASSWORD}
+      insecure: true
+      forcepathstyle: true
     wal:
       path: /var/tempo/wal
+    cache: inmemory
+
+compactor:
+  compaction:
+    block_retention: 4320h  # 180 days


### PR DESCRIPTION
### Summary
Added min.io for object storage. Updated LGTM otel stack configs to use it for storage.

### Changes
- Documentation
- New feature

### Details
- Add min.io container to AppHost.cs
- Add sister container to generate required buckets on start
- Update AppHost orchestration to pass S3 basic auth creds, allow env var injection for configs
- Update LGTM stack configs for S3 storage
- Update README for MinIO user secrets

### Testing
Ran AppHost to observe bucket generation and otel data storage.

### Checklist
- [X] Code compiles without warnings or errors
- [X] Unit/integration tests added or updated (if applicable)
- [X] Documentation updated (README, ADRs, etc.)
- [X] License headers / notices applied where required